### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -12,7 +12,7 @@ cta:
 secondary:
   - Open on GitHub →
   - https://github.com/gaetansenn/nuxt-loco
-snippet: npm install nuxt-loco
+snippet: npx nuxi@latest module add nuxt-loco
 ---
 
 #title

--- a/docs/content/1.guide/0.index.md
+++ b/docs/content/1.guide/0.index.md
@@ -3,21 +3,9 @@
 Let's get started with nuxt-loco.
 
 1. Install the dependencies in your Nuxt project:
-
-::code-group
-
-  ```bash [yarn]
-  yarn install nuxt-loco
-  ```
-
-  ```bash [npm]
-  npm install nuxt-loco
-  ```
-
-  ```bash [pnpm]
-  pnpm install nuxt-loco
-  ```
-::
+```bash
+npx nuxi@latest module add nuxt-loco
+```
 
 2. Configure your `nuxt.config.ts` to load the module
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
